### PR TITLE
Only remove github and ssh keys if they've been added

### DIFF
--- a/drupal-fancy/php/composer-install.sh
+++ b/drupal-fancy/php/composer-install.sh
@@ -24,8 +24,13 @@ cd /tmp/composer || exit
 composer install --dev
 
 # Remove the private key and token to leave no traces in the image.
-composer config -g github-oauth.github.com deleted
-rm /root/.ssh/id_rsa
+if [ -n "$GITHUB_PRIVATE_TOKEN" ]; then
+  composer config -g github-oauth.github.com deleted
+fi
+
+if [ -n "$SSH_PRIVATE_KEY" ]; then
+  rm /root/.ssh/id_rsa
+fi
 
 # Copy dependencies into place.
 rsync -qrtvu --delete /tmp/composer/ /var/www/


### PR DESCRIPTION
If you don't have a private SSH key to add, `dork-compose up` will fail trying to remove the nonexistent key. This PR wraps the ssh and github key deletion in the same conditional we used to create them.
